### PR TITLE
fixed branching and cout -> cerr

### DIFF
--- a/src/instructionList.cpp
+++ b/src/instructionList.cpp
@@ -149,12 +149,12 @@ uint32_t I_TYPE(std::vector<std::string>& argVec, const std::vector<OP_TYPE>& op
             case imm:
                 if (branch && labelReturn(argVec[i+1], immediate)) {
                     immediate = immediate - ((pc+1)*4 + 0x10000000);
+                    immediate = immediate >> 2;
+
                 } else {
                     if (!validIntStr(argVec[i+1], immediate))
                         exitError("Invalid instruction argument \"" + giveStr(argVec) + "\" on instruction number " + std::to_string(pc+1), 5);
                 }
-                if (branch)
-                    immediate = immediate >> 2;
                 returnNum = returnNum | (immediate & 0xFFFF);
                 break;
             case $t:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,30 +9,30 @@ std::string formatName(std::string str);
 int main(int argc, char* argv[]) {
 
 	std::vector< std::vector<std::string> > commVector;
-	std::cout << std::endl;
+	std::cerr << std::endl;
 
 	if (argc == 1) {
-		std::cout << "------------------------------------- " << std::endl;
-		std::cout << "*********** CONSOLE INPUT *********** " << std::endl;
-		std::cout << "------------------------------------- " << std::endl << std::endl;
+		std::cerr << "------------------------------------- " << std::endl;
+		std::cerr << "*********** CONSOLE INPUT *********** " << std::endl;
+		std::cerr << "------------------------------------- " << std::endl << std::endl;
 		vecParser(std::cin, commVector);
 	} else {
 		std::string inFileName = argv[1];
 		std::ifstream inFile(inFileName);
 		if (!inFile.is_open()) {
-			std::cout << "Unable to open file." << std::endl << std::endl;
+			std::cerr << "Unable to open file." << std::endl << std::endl;
 			std::exit(0);
 		}
 		vecParser(inFile, commVector);
 		inFile.close();
 	}
 
-	std::cout << std::endl << "Commands passed successfully." << std::endl;
+	std::cerr << std::endl << "Commands passed successfully." << std::endl;
 
 	std::string outFileName;
 	
 	if (argc == 1) {
-		std::cout << "Please enter an output file name: ";
+		std::cerr << "Please enter an output file name: ";
 		std::cin >> outFileName;
 	} else {
 		outFileName = formatName(argv[1]);
@@ -48,13 +48,13 @@ int main(int argc, char* argv[]) {
 
 	std::ofstream outFile(outFileName, std::ios::binary);
 	if (!outFile.is_open()) {
-		std::cout << "Unable to generate output file." << std::endl << std::endl;
+		std::cerr << "Unable to generate output file." << std::endl << std::endl;
 		std::exit(5);
 	}
 	binGen(outFile, commVector);
 	outFile.close();
 
-	std::cout << "Output file generated: " << outFileName << std::endl << std::endl;
+	std::cerr << "Output file generated: " << outFileName << std::endl << std::endl;
 }
 
 std::string formatName(std::string str) {


### PR DESCRIPTION
Changed all cout to cerr so that if the testbench calls the parser, it does not read the stdout from the parser.

Also the branch instruction was broken, before it shifted the immediate 2 bits, it should just leave it the value of the immediate given in assembly, (we left shift 2 in the simulator for word alignment/saving bit space ie only needing 16 bits to represent 18).

The branch using a label was correct before.

Now something like this:

`bne $3, $0, -3`

should branch to the 3rd instruction before the delay slot

https://youtu.be/1bP6alXjDrw?t=249